### PR TITLE
BugFix: String.replaceAll in getPaymentKey and getExecutionKey

### DIFF
--- a/src/com/mangopay/core/APIs/ApiPayIns.java
+++ b/src/com/mangopay/core/APIs/ApiPayIns.java
@@ -76,7 +76,7 @@ public class ApiPayIns extends ApiBase {
         if (payIn.PaymentDetails == null)
             throw new Exception ("Payment is not defined or it is not object type");
         
-        String className = payIn.PaymentDetails.getClass().getName().replaceAll("com.mangopay.entities.subentities.PayInPaymentDetails", "");
+        String className = payIn.PaymentDetails.getClass().getName().replace("com.mangopay.entities.subentities.PayInPaymentDetails", "");
         return className.toLowerCase();
     }
     
@@ -85,7 +85,7 @@ public class ApiPayIns extends ApiBase {
         if (payIn.ExecutionDetails == null)
             throw new Exception ("Execution is not defined or it is not object type");
         
-        String className = payIn.ExecutionDetails.getClass().getName().replaceAll("com.mangopay.entities.subentities.PayInExecutionDetails", "");
+        String className = payIn.ExecutionDetails.getClass().getName().replace("com.mangopay.entities.subentities.PayInExecutionDetails", "");
         return className.toLowerCase();
     }
     


### PR DESCRIPTION
BugFix: String.replaceAll in getPaymentKey and getExecutionKey does not replace the classname namespace because the replacement string contains regexp special characters. Therefore the key for pay in is not recognized and pay in fails.

Using String.replace instead of String.replaceAll is more appropriate in this case and fixes the issue.