### PR TITLE
Fix read Mangopay SDK version properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,17 @@ tasks.withType(Javadoc) {
     options.addStringOption('charSet', 'UTF-8')
 }
 
-void createVersionFile() {
-    Properties props = new Properties()
-    props.setProperty("version", (String) version)
-    File f = new File("version.properties")
-    OutputStream out = new FileOutputStream(f)
-    props.store(out, "Version file.")
+task updatePropertiesFile {
+    doLast {
+        logger.quiet('Update Mangopay Properties File')
+        def propertyFile = file "src/main/resources/com/mangopay/core/mangopay.properties"
+        def props = new Properties()
+        propertyFile.withReader { props.load(it) }
+        props.setProperty("version", (String) version)
+        propertyFile.withWriter { props.store(it, null) }
+    }
 }
 
-createVersionFile()
+
+processResources.dependsOn updatePropertiesFile
+

--- a/src/main/java/com/mangopay/core/APIs/ApiBase.java
+++ b/src/main/java/com/mangopay/core/APIs/ApiBase.java
@@ -15,6 +15,10 @@ public abstract class ApiBase {
      */
     protected MangoPayApi root;
 
+    protected MangoPayApi getRoot() {
+        return root;
+    }
+    
     /**
      * Array with REST URL and request type.
      */

--- a/src/main/java/com/mangopay/core/APIs/implementation/OAuthApiImpl.java
+++ b/src/main/java/com/mangopay/core/APIs/implementation/OAuthApiImpl.java
@@ -7,14 +7,10 @@ import com.mangopay.core.AuthenticationHelper;
 import com.mangopay.core.OAuthToken;
 import com.mangopay.core.RestTool;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -55,21 +51,10 @@ public class OAuthApiImpl extends ApiBase implements ApiOAuth {
             Logger.getLogger(OAuthApiImpl.class.getName()).log(Level.SEVERE, null, ex);
         }
         rest.addRequestHttpHeader("Content-Type", "application/x-www-form-urlencoded");
-        rest.addRequestHttpHeader("User-Agent", "MangoPay V2 JAVA/" + getProjectVersion());
+        rest.addRequestHttpHeader("User-Agent",  String.format("MangoPay V2 JAVA/%s", getRoot().getConfig().getVersion()));
         OAuthToken response = rest.request(OAuthToken.class, null, urlMethod, requestType, requestData);
 
         return response;
     }
 
-    private String getProjectVersion() {
-        Properties prop = new Properties();
-        try (InputStream input = new FileInputStream("version.properties")) {
-            // load a properties file
-            prop.load(input);
-            return prop.getProperty("version");
-        } catch (IOException ex) {
-            ex.printStackTrace();
-        }
-        return null;
-    }
 }

--- a/src/main/java/com/mangopay/core/Configuration.java
+++ b/src/main/java/com/mangopay/core/Configuration.java
@@ -1,5 +1,11 @@
 package com.mangopay.core;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Configuration settings.
  */
@@ -46,6 +52,12 @@ public class Configuration {
      * Connection Read Timeout.
      */
     private int readTimeout = 60000;
+    
+    /**
+     * Mangopay SDK Version
+     */
+    private String version;
+    
 
     public String getClientId() {
         return ClientId;
@@ -113,5 +125,33 @@ public class Configuration {
      */
     public void setReadTimeout(int readTimeout) {
         this.readTimeout = readTimeout;
+    }
+
+    
+    /**
+     * Get Mangopay SDK Version
+     * @return String Mangopay Version
+     */
+    public String getVersion() {
+        if (ObjectTool.isNull(version)) {
+            version = readMangopayVersion();
+        }
+        return version;
+    }
+
+    /**
+     * Read Mangopay version from mangopay properties
+     * @return String Mangopay Version
+     */
+    private String readMangopayVersion() {
+        try {
+            Properties prop = new Properties();
+            InputStream input = getClass().getResourceAsStream("mangopay.properties");
+            prop.load(input);
+            return prop.getProperty("version");
+        } catch (IOException ex) {
+            Logger.getLogger(Configuration.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        return "unknown";
     }
 }

--- a/src/main/resources/com/mangopay/core/mangopay.properties
+++ b/src/main/resources/com/mangopay/core/mangopay.properties
@@ -1,0 +1,2 @@
+#Wed Feb 22 12:11:38 CET 2017
+version=1.3.0

--- a/src/test/java/com/mangopay/core/BaseTest.java
+++ b/src/test/java/com/mangopay/core/BaseTest.java
@@ -58,6 +58,10 @@ public abstract class BaseTest {
     public void tearDown() {
     }
 
+    protected MangoPayApi getApi() {
+        return api;
+    }
+
     protected final MangoPayApi buildNewMangoPayApi() {
         MangoPayApi newApi = new MangoPayApi();
 

--- a/src/test/java/com/mangopay/core/ConfigurationsTest.java
+++ b/src/test/java/com/mangopay/core/ConfigurationsTest.java
@@ -1,5 +1,6 @@
 package com.mangopay.core;
 
+import static org.junit.Assert.*;
 import org.junit.Test;
 
 /**
@@ -12,5 +13,13 @@ public class ConfigurationsTest extends BaseTest {
         this.api.getConfig().setClientId("test_asd");
         this.api.getConfig().setClientPassword("00000");
         this.api.getUserApi().getAll();
+    }
+    
+    @Test
+    public void getVersionTest() {
+        // First load from properties files
+        assertNotNull(getApi().getConfig().getVersion());
+        // Second load from memory
+        assertNotNull(getApi().getConfig().getVersion());
     }
 }


### PR DESCRIPTION
I updated a project to 1.3.0 library version, it is working but I receive this exception in the logs.
```
java.io.FileNotFoundException: version.properties (No such file or directory)
	at java.io.FileInputStream.open0(Native Method)
	at java.io.FileInputStream.open(FileInputStream.java:195)
	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at java.io.FileInputStream.<init>(FileInputStream.java:93)
	at com.mangopay.core.APIs.implementation.OAuthApiImpl.getProjectVersion(OAuthApiImpl.java:66)
22-Feb-2017 09:04:04.714 INFO [main] org.apache.coyote.AbstractProtocol.start Starting ProtocolHandler ["http-nio-8080"]
	at com.mangopay.core.APIs.implementation.OAuthApiImpl.createToken(OAuthApiImpl.java:58)
	at com.mangopay.core.AuthorizationTokenManager.getToken(AuthorizationTokenManager.java:39)
	at com.mangopay.core.AuthenticationHelper.getHttpHeaderStrong(AuthenticationHelper.java:61)
	at com.mangopay.core.AuthenticationHelper.getHttpHeaderKey(AuthenticationHelper.java:30)
	at com.mangopay.core.RestTool.getHttpHeaders(RestTool.java:912)
	at com.mangopay.core.RestTool.doRequest(RestTool.java:336)
	at com.mangopay.core.RestTool.request(RestTool.java:142)
	at com.mangopay.core.RestTool.request(RestTool.java:166)
	at com.mangopay.core.APIs.ApiBase.getObject(ApiBase.java:266)
	at com.mangopay.core.APIs.ApiBase.getObject(ApiBase.java:281)
	at com.mangopay.core.APIs.implementation.WalletApiImpl.get(WalletApiImpl.java:33)
```
I make changes in the project to fix this bug and add improvements.
