### PR TITLE
2-2.01 Compatibility Patch

### DIFF
--- a/src/main/java/com/mangopay/MangoPayApi.java
+++ b/src/main/java/com/mangopay/MangoPayApi.java
@@ -25,6 +25,7 @@ public class MangoPayApi {
         setAuthenticationManager(new OAuthApiImpl(this));
         setClientApi(new ClientApiImpl(this));
         setUserApi(new UserApiImpl(this));
+        setLegacyUserApi(new LegacyUserApiImpl(this));
         setWalletApi(new WalletApiImpl(this));
         setPayInApi(new PayInApiImpl(this));
         setPayOutApi(new PayOutApiImpl(this));
@@ -42,6 +43,10 @@ public class MangoPayApi {
         setReportApi(new ReportApiImpl(this));
         setBankingAliasApi(new BankingAliasApiImpl(this));
     }
+
+    /**
+     * Instantiates a new MangoPayApi object for a certain API version.
+     */
 
     ////////////////////////////////////////
     // Config/authorization related fields
@@ -75,6 +80,11 @@ public class MangoPayApi {
      * Provides Users methods.
      */
     private UserApi users;
+
+    /**
+     * Provides compatibility Users methods.
+     */
+    private LegacyUserApi legacyUsers;
 
     /**
      * Provides Wallets methods.
@@ -189,11 +199,25 @@ public class MangoPayApi {
     }
 
     public UserApi getUserApi() {
+        if (config.getApiVersion().equals(Configuration.VERSION_2)) {
+            throw new IllegalStateException("Standard version of API requires setting a higher API version in the Configuration");
+        }
         return users;
     }
 
     public void setUserApi(UserApi users) {
         this.users = users;
+    }
+
+    public LegacyUserApi getLegacyUserApi() {
+        if (!config.getApiVersion().equals(Configuration.VERSION_2)) {
+            throw new IllegalStateException("Legacy version of API requires setting a lower API version in the Configuration");
+        }
+        return legacyUsers;
+    }
+
+    public void setLegacyUserApi(LegacyUserApi legacyUsers) {
+        this.legacyUsers = legacyUsers;
     }
 
     public WalletApi getWalletApi() {

--- a/src/main/java/com/mangopay/MangoPayApi.java
+++ b/src/main/java/com/mangopay/MangoPayApi.java
@@ -44,10 +44,6 @@ public class MangoPayApi {
         setBankingAliasApi(new BankingAliasApiImpl(this));
     }
 
-    /**
-     * Instantiates a new MangoPayApi object for a certain API version.
-     */
-
     ////////////////////////////////////////
     // Config/authorization related fields
     ////////////////////////////////////////

--- a/src/main/java/com/mangopay/core/APIs/LegacyUserApi.java
+++ b/src/main/java/com/mangopay/core/APIs/LegacyUserApi.java
@@ -1,0 +1,311 @@
+package com.mangopay.core.APIs;
+
+import com.mangopay.core.FilterTransactions;
+import com.mangopay.core.Pagination;
+import com.mangopay.core.Sorting;
+import com.mangopay.core.enumerations.CurrencyIso;
+import com.mangopay.core.enumerations.KycDocumentType;
+import com.mangopay.entities.*;
+
+import java.util.List;
+
+/**
+ * Compatibility version of {@link UserApi}.
+ * Created by thepa on 05-Jul-17.
+ */
+public interface LegacyUserApi {
+
+    /**
+     * Gets user.
+     *
+     * @param userId User identifier.
+     * @return User instance returned from API, which is either of UserNatural or UserLegal type.
+     * @throws Exception
+     */
+    User get(String userId) throws Exception;
+
+    /**
+     * Creates new user.
+     *
+     * @param user User object to be created.
+     * @return User instance returned from API, which is either of UserNatural or UserLegal type.
+     * @throws Exception
+     */
+    User create(User user) throws Exception;
+
+    /**
+     * Creates new user.
+     *
+     * @param idempotencyKey idempotency key for this request.
+     * @param user           User object to be created.
+     * @return User instance returned from API, which is either of UserNatural or UserLegal type.
+     * @throws Exception
+     */
+    User create(String idempotencyKey, User user) throws Exception;
+
+    /**
+     * Gets page of users.
+     *
+     * @param pagination Pagination object.
+     * @return Collection of User instances.
+     * @throws Exception
+     */
+    List<User> getAll(Pagination pagination, Sorting sorting) throws Exception;
+
+    /**
+     * Gets first page of users.
+     *
+     * @return Collection of User instances.
+     * @throws Exception
+     */
+    List<User> getAll() throws Exception;
+
+    /**
+     * Gets natural user by its identifier,
+     *
+     * @param userId UserNatural identifier.
+     * @return UserNatural object returned from API.
+     * @throws Exception
+     */
+    LegacyUserNatural getNatural(String userId) throws Exception;
+
+    /**
+     * Gets legal user by its identifier.
+     *
+     * @param userId UserLegal identifier.
+     * @return UserLegal object returned from API.
+     * @throws Exception
+     */
+    LegacyUserLegal getLegal(String userId) throws Exception;
+
+    /**
+     * Updates the user.
+     *
+     * @param user Instance of UserNatural or UserLegal class to be updated.
+     * @return Updated User object returned from API.
+     * @throws Exception
+     */
+    User update(User user) throws Exception;
+
+    /**
+     * Creates bank account for user.
+     *
+     * @param userId      User identifier to create bank account for.
+     * @param bankAccount Bank account object.
+     * @return Created bank account object returned from API.
+     * @throws Exception
+     */
+    BankAccount createBankAccount(String userId, BankAccount bankAccount) throws Exception;
+
+    /**
+     * Creates bank account for user.
+     *
+     * @param idempotencyKey idempotency key for this request.
+     * @param userId         User identifier to create bank account for.
+     * @param bankAccount    Bank account object.
+     * @return Created bank account object returned from API.
+     * @throws Exception
+     */
+    BankAccount createBankAccount(String idempotencyKey, String userId, BankAccount bankAccount) throws Exception;
+
+    /**
+     * Updates bank account.
+     *
+     * @param userId        User identifier.
+     * @param bankAccount   Bank account object.
+     * @param bankAccountId Bank account identifier.
+     * @return Updated bank account object returned from API.
+     * @throws Exception
+     */
+    BankAccount updateBankAccount(String userId, BankAccount bankAccount, String bankAccountId) throws Exception;
+
+    /**
+     * Gets all bank accounts of user.
+     *
+     * @param userId     User identifier to get bank accounts of.
+     * @param pagination Pagination object.
+     * @param sorting    Sorting object.
+     * @return Collection of bank accounts of user.
+     * @throws Exception
+     */
+    List<BankAccount> getBankAccounts(String userId, Pagination pagination, Sorting sorting) throws Exception;
+
+    /**
+     * Gets first page of all bank accounts of user.
+     *
+     * @param userId User identifier to get bank accounts of.
+     * @return Collection of bank accounts of user.
+     * @throws Exception
+     */
+    List<BankAccount> getBankAccounts(String userId) throws Exception;
+
+    /**
+     * Gets bank account of user.
+     *
+     * @param userId        User identifier.
+     * @param bankAccountId Bank account identifier.
+     * @return Bank account object returned from API.
+     * @throws Exception
+     */
+    BankAccount getBankAccount(String userId, String bankAccountId) throws Exception;
+
+    /**
+     * Gets all wallets of user.
+     *
+     * @param userId     User identifier to get bank accounts of.
+     * @param pagination Pagination object.
+     * @param sorting    Sorting object.
+     * @return Collection of wallets of user.
+     * @throws Exception
+     */
+    List<Wallet> getWallets(String userId, Pagination pagination, Sorting sorting) throws Exception;
+
+    /**
+     * Gets first page of all wallets of user.
+     *
+     * @param userId User identifier to get bank accounts of.
+     * @return Collection of wallets of user.
+     * @throws Exception
+     */
+    List<Wallet> getWallets(String userId) throws Exception;
+
+    /**
+     * Gets transactions for user.
+     *
+     * @param userId     User identifier.
+     * @param pagination Pagination object.
+     * @param filter     Filter object.
+     * @param sorting    Sorting object.
+     * @return Collection of transactions of user.
+     * @throws Exception
+     */
+    List<Transaction> getTransactions(String userId, Pagination pagination, FilterTransactions filter, Sorting sorting) throws Exception;
+
+    /**
+     * Gets all cards for user.
+     *
+     * @param userId     User identifier.
+     * @param pagination Pagination object.
+     * @param sorting    Sorting object.
+     * @return Collection of user's cards.
+     * @throws Exception
+     */
+    List<Card> getCards(String userId, Pagination pagination, Sorting sorting) throws Exception;
+
+    /**
+     * Creates KycPage from byte array.
+     *
+     * @param userId        User identifier.
+     * @param kycDocumentId Kyc document identifier.
+     * @param binaryData    The byte array the KycPage will be created from.
+     * @throws Exception
+     */
+    void createKycPage(String userId, String kycDocumentId, byte[] binaryData) throws Exception;
+
+    /**
+     * Creates KycPage from byte array.
+     *
+     * @param idempotencyKey idempotency key for this request.
+     * @param userId         User identifier.
+     * @param kycDocumentId  Kyc document identifier.
+     * @param binaryData     The byte array the KycPage will be created from.
+     * @throws Exception
+     */
+    void createKycPage(String idempotencyKey, String userId, String kycDocumentId, byte[] binaryData) throws Exception;
+
+    /**
+     * Creates KycPage from file.
+     *
+     * @param userId        User identifier.
+     * @param kycDocumentId Kyc document identifier.
+     * @param filePath      Path to the file the KycPage will be created from.
+     * @throws Exception
+     */
+    void createKycPage(String userId, String kycDocumentId, String filePath) throws Exception;
+
+    /**
+     * Creates KycPage from file.
+     *
+     * @param idempotencyKey idempotency key for this request.
+     * @param userId         User identifier.
+     * @param kycDocumentId  Kyc document identifier.
+     * @param filePath       Path to the file the KycPage will be created from.
+     * @throws Exception
+     */
+    void createKycPage(String idempotencyKey, String userId, String kycDocumentId, String filePath) throws Exception;
+
+    /**
+     * Creates KycDocument.
+     *
+     * @param userId User identifier.
+     * @param type   Type of KycDocument.
+     * @return KycDocument object returned from API.
+     * @throws Exception
+     */
+    KycDocument createKycDocument(String userId, KycDocumentType type) throws Exception;
+
+    /**
+     * Creates KycDocument.
+     *
+     * @param idempotencyKey idempotency key for this request.
+     * @param userId         User identifier.
+     * @param type           Type of KycDocument.
+     * @return KycDocument object returned from API.
+     * @throws Exception
+     */
+    KycDocument createKycDocument(String idempotencyKey, String userId, KycDocumentType type) throws Exception;
+
+    /**
+     * Gets KycDocument.
+     *
+     * @param userId        User identifier.
+     * @param kycDocumentId KycDocument identifier.
+     * @return KycDocument object returned from API.
+     * @throws Exception
+     */
+    KycDocument getKycDocument(String userId, String kycDocumentId) throws Exception;
+
+    /**
+     * Updates KycDocument.
+     *
+     * @param userId      User identifier.
+     * @param kycDocument KycDocument entity instance to be updated.
+     * @return KycDocument object returned from API.
+     * @throws Exception
+     */
+    KycDocument updateKycDocument(String userId, KycDocument kycDocument) throws Exception;
+
+    /**
+     * Gets all KYC documents for single user.
+     *
+     * @param userId     User identifier.
+     * @param pagination Pagination.
+     * @param sorting    Sorting object.
+     * @return List of KycDocuments returned from API.
+     * @throws Exception
+     */
+    List<KycDocument> getKycDocuments(String userId, Pagination pagination, Sorting sorting) throws Exception;
+
+    /**
+     * Shows the e-money cash-in/cash-out amounts for a particular user.
+     * Result will be in <code>EUR</code> due to lack of a specified currency.
+     *
+     * @param userId Id of the user whose e-money data to get.
+     * @return EMoney data for the specified user.
+     * @throws Exception
+     */
+    EMoney getEMoney(String userId) throws Exception;
+
+    /**
+     * Shows the e-money cash-in/cash-out amounts for a particular user.
+     * The Currency parameter can be used to have the amounts specified in a certain currency.
+     *
+     * @param userId Id of the user whose e-money data to get.
+     * @param currencyIso Currency in which to format money amounts. If <code>null</code>, will be considered
+     *                   as <code>EUR</code>.
+     * @return EMoney data for the specified user.
+     * @throws Exception
+     */
+    EMoney getEMoney(String userId, CurrencyIso currencyIso) throws Exception;
+
+}

--- a/src/main/java/com/mangopay/core/APIs/implementation/LegacyUserApiImpl.java
+++ b/src/main/java/com/mangopay/core/APIs/implementation/LegacyUserApiImpl.java
@@ -1,0 +1,229 @@
+package com.mangopay.core.APIs.implementation;
+
+import com.mangopay.MangoPayApi;
+import com.mangopay.core.APIs.ApiBase;
+import com.mangopay.core.APIs.LegacyUserApi;
+import com.mangopay.core.FilterTransactions;
+import com.mangopay.core.Pagination;
+import com.mangopay.core.Sorting;
+import com.mangopay.core.enumerations.CurrencyIso;
+import com.mangopay.core.enumerations.KycDocumentType;
+import com.mangopay.entities.*;
+import org.apache.commons.codec.binary.Base64;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Created by thepa on 05-Jul-17.
+ */
+public class LegacyUserApiImpl extends ApiBase implements LegacyUserApi {
+
+    /**
+     * Instantiates new UserApiImpl object.
+     *
+     * @param root Root/parent instance that holds the OAuthToken and Configuration instance.
+     */
+    public LegacyUserApiImpl(MangoPayApi root) {
+        super(root);
+    }
+
+    @Override
+    public User get(String userId) throws Exception {
+        return this.getObject(User.class, "users_get", userId);
+    }
+
+    @Override
+    public User create(User user) throws Exception {
+        return create(null, user);
+    }
+
+    @Override
+    public User create(String idempotencyKey, User user) throws Exception {
+
+        User response = null;
+
+        if (user instanceof UserNatural)
+            response = this.createObject(UserNatural.class, idempotencyKey, "users_createnaturals", (UserNatural) user);
+        else if (user instanceof UserLegal)
+            response = this.createObject(UserLegal.class, idempotencyKey, "users_createlegals", (UserLegal) user);
+        else
+            throw new Exception("Unsupported user entity type.");
+
+        return response;
+    }
+
+    @Override
+    public List<User> getAll(Pagination pagination, Sorting sorting) throws Exception {
+        return this.getList(User[].class, User.class, "users_all", pagination, sorting);
+    }
+
+    @Override
+    public List<User> getAll() throws Exception {
+        return getAll(null, null);
+    }
+
+    @Override
+    public LegacyUserNatural getNatural(String userId) throws Exception {
+        return this.getObject(LegacyUserNatural.class, "users_getnaturals", userId);
+    }
+
+    @Override
+    public LegacyUserLegal getLegal(String userId) throws Exception {
+        return this.getObject(LegacyUserLegal.class, "users_getlegals", userId);
+    }
+
+    @Override
+    public User update(User user) throws Exception {
+
+        String methodKey = "";
+        if (user instanceof UserNatural)
+            methodKey = "users_savenaturals";
+        else if (user instanceof UserLegal)
+            methodKey = "users_savelegals";
+        else
+            throw new Exception("Unsupported user entity type.");
+
+        return this.updateObject(User.class, methodKey, user);
+    }
+
+    @Override
+    public BankAccount createBankAccount(String userId, BankAccount bankAccount) throws Exception {
+        return this.createBankAccount(null, userId, bankAccount);
+    }
+
+    @Override
+    public BankAccount createBankAccount(String idempotencyKey, String userId, BankAccount bankAccount) throws Exception {
+        String type = this.getBankAccountType(bankAccount);
+        return this.createObject(BankAccount.class, idempotencyKey, "users_createbankaccounts_" + type, bankAccount, userId);
+    }
+
+    @Override
+    public BankAccount updateBankAccount(String userId, BankAccount bankAccount, String bankAccountId) throws Exception {
+        return this.updateObject(BankAccount.class, "users_savebankaccount", bankAccount, userId, bankAccountId);
+    }
+
+    @Override
+    public List<BankAccount> getBankAccounts(String userId, Pagination pagination, Sorting sorting) throws Exception {
+        return this.getList(BankAccount[].class, BankAccount.class, "users_allbankaccount", pagination, userId, sorting);
+    }
+
+    @Override
+    public List<BankAccount> getBankAccounts(String userId) throws Exception {
+        return getBankAccounts(userId, null, null);
+    }
+
+    @Override
+    public BankAccount getBankAccount(String userId, String bankAccountId) throws Exception {
+        return this.getObject(BankAccount.class, "users_getbankaccount", userId, bankAccountId);
+    }
+
+    @Override
+    public List<Wallet> getWallets(String userId, Pagination pagination, Sorting sorting) throws Exception {
+        return this.getList(Wallet[].class, Wallet.class, "users_allwallets", pagination, userId, sorting);
+    }
+
+    @Override
+    public List<Wallet> getWallets(String userId) throws Exception {
+        return getWallets(userId, null, null);
+    }
+
+    @Override
+    public List<Transaction> getTransactions(String userId, Pagination pagination, FilterTransactions filter, Sorting sorting) throws Exception {
+        return this.getList(Transaction[].class, Transaction.class, "users_alltransactions", pagination, userId, filter.getValues(), sorting);
+    }
+
+    @Override
+    public List<Card> getCards(String userId, Pagination pagination, Sorting sorting) throws Exception {
+        return this.getList(Card[].class, Card.class, "users_allcards", pagination, userId, sorting);
+    }
+
+    @Override
+    public void createKycPage(String userId, String kycDocumentId, byte[] binaryData) throws Exception {
+        createKycPage(null, userId, kycDocumentId, binaryData);
+    }
+
+    @Override
+    public void createKycPage(String idempotencyKey, String userId, String kycDocumentId, byte[] binaryData) throws Exception {
+        KycPage kycPage = new KycPage();
+
+        String fileContent = new String(Base64.encodeBase64(binaryData));
+
+        kycPage.setFile(fileContent);
+
+        this.createObject(KycPage.class, idempotencyKey, "kyc_page_create", kycPage, userId, kycDocumentId);
+    }
+
+    @Override
+    public void createKycPage(String userId, String kycDocumentId, String filePath) throws Exception {
+        byte[] fileArray;
+        Path path = Paths.get(filePath);
+        fileArray = Files.readAllBytes(path);
+
+        createKycPage(userId, kycDocumentId, fileArray);
+    }
+
+    @Override
+    public void createKycPage(String idempotencyKey, String userId, String kycDocumentId, String filePath) throws Exception {
+        byte[] fileArray;
+        Path path = Paths.get(filePath);
+        fileArray = Files.readAllBytes(path);
+
+        createKycPage(idempotencyKey, userId, kycDocumentId, fileArray);
+    }
+
+    @Override
+    public KycDocument createKycDocument(String userId, KycDocumentType type) throws Exception {
+        return createKycDocument(null, userId, type);
+    }
+
+    @Override
+    public KycDocument createKycDocument(String idempotencyKey, String userId, KycDocumentType type) throws Exception {
+        KycDocument kycDocument = new KycDocument();
+        kycDocument.setType(type);
+
+        return this.createObject(KycDocument.class, idempotencyKey, "users_createkycdocument", kycDocument, userId);
+    }
+
+    @Override
+    public KycDocument getKycDocument(String userId, String kycDocumentId) throws Exception {
+        return this.getObject(KycDocument.class, "users_getkycdocument", userId, kycDocumentId);
+    }
+
+    @Override
+    public KycDocument updateKycDocument(String userId, KycDocument kycDocument) throws Exception {
+        return this.updateObject(KycDocument.class, "users_savekycdocument", kycDocument, userId);
+    }
+
+    @Override
+    public List<KycDocument> getKycDocuments(String userId, Pagination pagination, Sorting sorting) throws Exception {
+        return this.getList(KycDocument[].class, KycDocument.class, "users_allkycdocuments", pagination, userId, sorting);
+    }
+
+    private String getBankAccountType(BankAccount bankAccount) throws Exception {
+
+        if (bankAccount.getDetails() == null)
+            throw new Exception("Details is not defined.");
+
+        String className = bankAccount.getDetails().getClass().getSimpleName().replace("BankAccountDetails", "");
+        return className.toLowerCase();
+    }
+
+    @Override
+    public EMoney getEMoney(String userId) throws Exception {
+        if (userId == null) {
+            throw new Exception("Cannot get EMoney without specifying the userId");
+        }
+        return this.getObject(EMoney.class, "users_emoney", userId);
+    }
+
+    @Override
+    public EMoney getEMoney(String userId, CurrencyIso currencyIso) throws Exception {
+        if (currencyIso == null) {
+            return this.getEMoney(userId);
+        }
+        return this.getObject(EMoney.class, "users_emoney_currency", userId, currencyIso.name());
+    }
+}

--- a/src/main/java/com/mangopay/core/Address.java
+++ b/src/main/java/com/mangopay/core/Address.java
@@ -118,4 +118,21 @@ public class Address extends Dto {
                 (Country != null && Country != CountryIso.NotSpecified);
 
     }
+
+    @Override
+    public String toString() {
+        String address = "";
+        address += getAddressLine1() != null && !getAddressLine1().isEmpty() ? getAddressLine1() : "";
+        address += getAddressLine2() != null && !getAddressLine2().isEmpty() ? (!address.isEmpty() ? ", " : "") + getAddressLine2() : "";
+        String details = !address.isEmpty() ? ", " : "";
+        details += getCity() != null && !getCity().isEmpty() ? getCity() + ", " : "";
+        details += getRegion() != null && !getRegion().isEmpty() ? getRegion() + ", " : "";
+        details += getPostalCode() != null && !getPostalCode().isEmpty() ? getPostalCode() + ", " : "";
+        details += getCountry() != null ? getCountry() : "";
+        details = details.trim();
+        if (details.endsWith(",")) {
+            details = details.substring(0, details.length() - 1);
+        }
+        return (!address.isEmpty() ? address : "") + (!details.isEmpty() ? details : "");
+    }
 }

--- a/src/main/java/com/mangopay/core/Configuration.java
+++ b/src/main/java/com/mangopay/core/Configuration.java
@@ -146,8 +146,13 @@ public class Configuration {
         return apiVersion;
     }
 
+    /**
+     * Set the Mangopay API Version to use
+     *
+     * @param apiVersion The API Version to use (as defined in {@link Configuration}
+     */
     public void setApiVersion(String apiVersion) {
-        if(!(apiVersion.equals(VERSION_2) || apiVersion.equals(VERSION_2_01))) {
+        if (!(apiVersion.equals(VERSION_2) || apiVersion.equals(VERSION_2_01))) {
             throw new RuntimeException("Invalid API Version");
         }
         this.apiVersion = apiVersion;

--- a/src/main/java/com/mangopay/core/Configuration.java
+++ b/src/main/java/com/mangopay/core/Configuration.java
@@ -11,6 +11,10 @@ import java.util.logging.Logger;
  */
 public class Configuration {
 
+    public static final String
+            VERSION_2 = "v2",
+            VERSION_2_01 = "v2.01";
+
     /**
      * Client identifier.
      *
@@ -52,12 +56,17 @@ public class Configuration {
      * Connection Read Timeout.
      */
     private int readTimeout = 60000;
-    
+
     /**
      * Mangopay SDK Version
      */
     private String version;
-    
+
+    /**
+     * Mangopay API Version
+     */
+    private String apiVersion = VERSION_2_01;
+
 
     public String getClientId() {
         return ClientId;
@@ -127,9 +136,10 @@ public class Configuration {
         this.readTimeout = readTimeout;
     }
 
-    
+
     /**
      * Get Mangopay SDK Version
+     *
      * @return String Mangopay Version
      */
     public String getVersion() {
@@ -140,7 +150,24 @@ public class Configuration {
     }
 
     /**
+     * Get Mangopay API Version
+     *
+     * @return String Mangopay API Version
+     */
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public void setApiVersion(String apiVersion) {
+        if(!(apiVersion.equals(VERSION_2) || apiVersion.equals(VERSION_2_01))) {
+            throw new RuntimeException("Invalid API Version");
+        }
+        this.apiVersion = apiVersion;
+    }
+
+    /**
      * Read Mangopay version from mangopay properties
+     *
      * @return String Mangopay Version
      */
     private String readMangopayVersion() {

--- a/src/main/java/com/mangopay/core/UrlTool.java
+++ b/src/main/java/com/mangopay/core/UrlTool.java
@@ -87,9 +87,9 @@ class UrlTool {
         String url;
 
         if (!addClientId) {
-            url = "/v2.01" + urlKey;
+            url = "/" + root.getConfig().getApiVersion() + urlKey;
         } else {
-            url = "/v2.01/" + root.getConfig().getClientId() + urlKey;
+            url = "/" + root.getConfig().getApiVersion() + "/" + root.getConfig().getClientId() + urlKey;
         }
 
         Boolean paramsAdded = false;

--- a/src/main/java/com/mangopay/core/enumerations/ReportType.java
+++ b/src/main/java/com/mangopay/core/enumerations/ReportType.java
@@ -13,5 +13,10 @@ public enum ReportType {
     /**
      * Transactions type.
      */
-    TRANSACTIONS
+    TRANSACTIONS,
+    
+    /**
+    * Wallets type.
+    */
+    WALLETS
 }

--- a/src/main/java/com/mangopay/entities/LegacyUserLegal.java
+++ b/src/main/java/com/mangopay/entities/LegacyUserLegal.java
@@ -1,0 +1,225 @@
+package com.mangopay.entities;
+
+import com.google.gson.annotations.SerializedName;
+import com.mangopay.core.Address;
+import com.mangopay.core.enumerations.CountryIso;
+import com.mangopay.core.enumerations.LegalPersonType;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Map;
+
+import static com.mangopay.core.enumerations.PersonType.LEGAL;
+
+/**
+ * Compatibility version of {@link UserLegal}.
+ * Created by thepa on 05-Jul-17.
+ */
+public class LegacyUserLegal extends User {
+
+    /**
+     * Name of this user.
+     */
+    @SerializedName("Name")
+    private String name;
+
+    /**
+     * Type of legal user.
+     */
+    @SerializedName("LegalPersonType")
+    private LegalPersonType legalPersonType;
+
+    /**
+     * Headquarters address.
+     */
+    @SerializedName("HeadquartersAddress")
+    private String headquartersAddress;
+
+    /**
+     * Legal representative first name.
+     */
+    @SerializedName("LegalRepresentativeFirstName")
+    private String legalRepresentativeFirstName;
+
+    /**
+     * Legal representative last name.
+     */
+    @SerializedName("LegalRepresentativeLastName")
+    private String legalRepresentativeLastName;
+
+    /**
+     * Legal representative address.
+     */
+    @SerializedName("LegalRepresentativeAddress")
+    private String legalRepresentativeAddress;
+
+    /**
+     * Legal representative email.
+     */
+    @SerializedName("LegalRepresentativeEmail")
+    private String legalRepresentativeEmail;
+
+    /**
+     * Legal representative birthday.
+     */
+    @SerializedName("LegalRepresentativeBirthday")
+    private long legalRepresentativeBirthday;
+
+    /**
+     * Legal representative nationality.
+     */
+    @SerializedName("LegalRepresentativeNationality")
+    private CountryIso legalRepresentativeNationality;
+
+    /**
+     * Legal representative country of residence.
+     */
+    @SerializedName("LegalRepresentativeCountryOfResidence")
+    private CountryIso legalRepresentativeCountryOfResidence;
+
+    /**
+     * Statute.
+     */
+    @SerializedName("Statute")
+    private String statute;
+
+    /**
+     * Proof of registration.
+     */
+    @SerializedName("ProofOfRegistration")
+    private String proofOfRegistration;
+
+    /**
+     * Shareholder declaration.
+     */
+    @SerializedName("ShareholderDeclaration")
+    public String shareholderDeclaration;
+
+    /**
+     * Instantiates new LegacyUserLegal object.
+     */
+    public LegacyUserLegal() {
+        this.personType = LEGAL;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public LegalPersonType getLegalPersonType() {
+        return legalPersonType;
+    }
+
+    public void setLegalPersonType(LegalPersonType legalPersonType) {
+        this.legalPersonType = legalPersonType;
+    }
+
+    public String getHeadquartersAddress() {
+        return headquartersAddress;
+    }
+
+    public void setHeadquartersAddress(String headquartersAddress) {
+        this.headquartersAddress = headquartersAddress;
+    }
+
+    public String getLegalRepresentativeFirstName() {
+        return legalRepresentativeFirstName;
+    }
+
+    public void setLegalRepresentativeFirstName(String legalRepresentativeFirstName) {
+        this.legalRepresentativeFirstName = legalRepresentativeFirstName;
+    }
+
+    public String getLegalRepresentativeLastName() {
+        return legalRepresentativeLastName;
+    }
+
+    public void setLegalRepresentativeLastName(String legalRepresentativeLastName) {
+        this.legalRepresentativeLastName = legalRepresentativeLastName;
+    }
+
+    public String getLegalRepresentativeAddress() {
+        return legalRepresentativeAddress;
+    }
+
+    public void setLegalRepresentativeAddress(String legalRepresentativeAddress) {
+        this.legalRepresentativeAddress = legalRepresentativeAddress;
+    }
+
+    public String getLegalRepresentativeEmail() {
+        return legalRepresentativeEmail;
+    }
+
+    public void setLegalRepresentativeEmail(String legalRepresentativeEmail) {
+        this.legalRepresentativeEmail = legalRepresentativeEmail;
+    }
+
+    public long getLegalRepresentativeBirthday() {
+        return legalRepresentativeBirthday;
+    }
+
+    public void setLegalRepresentativeBirthday(long legalRepresentativeBirthday) {
+        this.legalRepresentativeBirthday = legalRepresentativeBirthday;
+    }
+
+    public CountryIso getLegalRepresentativeNationality() {
+        return legalRepresentativeNationality;
+    }
+
+    public void setLegalRepresentativeNationality(CountryIso legalRepresentativeNationality) {
+        this.legalRepresentativeNationality = legalRepresentativeNationality;
+    }
+
+    public CountryIso getLegalRepresentativeCountryOfResidence() {
+        return legalRepresentativeCountryOfResidence;
+    }
+
+    public void setLegalRepresentativeCountryOfResidence(CountryIso legalRepresentativeCountryOfResidence) {
+        this.legalRepresentativeCountryOfResidence = legalRepresentativeCountryOfResidence;
+    }
+
+    public String getStatute() {
+        return statute;
+    }
+
+    public void setStatute(String statute) {
+        this.statute = statute;
+    }
+
+    public String getProofOfRegistration() {
+        return proofOfRegistration;
+    }
+
+    public void setProofOfRegistration(String proofOfRegistration) {
+        this.proofOfRegistration = proofOfRegistration;
+    }
+
+    public String getShareholderDeclaration() {
+        return shareholderDeclaration;
+    }
+
+    public void setShareholderDeclaration(String shareholderDeclaration) {
+        this.shareholderDeclaration = shareholderDeclaration;
+    }
+
+    /**
+     * Gets the collection of read-only fields names.
+     *
+     * @return List of field names.
+     */
+    @Override
+    public ArrayList<String> getReadOnlyProperties() {
+
+        ArrayList<String> result = super.getReadOnlyProperties();
+
+        result.add("Statute");
+        result.add("ProofOfRegistration");
+        result.add("ShareholderDeclaration");
+
+        return result;
+    }
+}

--- a/src/main/java/com/mangopay/entities/LegacyUserNatural.java
+++ b/src/main/java/com/mangopay/entities/LegacyUserNatural.java
@@ -1,0 +1,212 @@
+package com.mangopay.entities;
+
+import com.google.gson.annotations.SerializedName;
+import com.mangopay.core.Address;
+import com.mangopay.core.enumerations.CountryIso;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Map;
+
+import static com.mangopay.core.enumerations.PersonType.NATURAL;
+
+/**
+ * Created by thepa on 05-Jul-17.
+ */
+public class LegacyUserNatural extends User {
+
+    /**
+     * First name.
+     */
+    @SerializedName("FirstName")
+    private String firstName;
+
+    /**
+     * Last name.
+     */
+    @SerializedName("LastName")
+    private String lastName;
+
+    /**
+     * Address.
+     */
+    @SerializedName("Address")
+    private String address;
+
+    /**
+     * Date of birth (UNIX timestamp).
+     */
+    @SerializedName("Birthday")
+    private long birthday;
+
+    /**
+     * Place of birth.
+     */
+    @SerializedName("Birthplace")
+    private String birthplace;
+
+    /**
+     * User's country.
+     */
+    @SerializedName("Nationality")
+    private CountryIso nationality;
+
+    /**
+     * Country of residence.
+     */
+    @SerializedName("CountryOfResidence")
+    private CountryIso countryOfResidence;
+
+    /**
+     * User's occupation.
+     */
+    @SerializedName("Occupation")
+    private String occupation;
+
+    /**
+     * Income ranges:
+     * 1 (-18K€),
+     * 2 (18-30K€),
+     * 3 (30-50K€),
+     * 4 (50-80K€),
+     * 5 (80-120K€),
+     * 6 (+120K€)
+     */
+    public static class IncomeRanges {
+        public static final Integer Below18 = 1;
+        public static final Integer From18To30 = 2;
+        public static final Integer From30To50 = 3;
+        public static final Integer From50To80 = 4;
+        public static final Integer From80To120 = 5;
+        public static final Integer Above120 = 6;
+    }
+
+    /**
+     * Income range. One of UserNatural.IncomeRanges constants.
+     */
+    @SerializedName("IncomeRange")
+    private Integer incomeRange;
+
+    /**
+     * Proof of identity.
+     */
+    @SerializedName("ProofOfIdentity")
+    protected String proofOfIdentity;
+
+    /**
+     * Proof of address.
+     */
+    @SerializedName("ProofOfAddress")
+    protected String proofOfAddress;
+
+    /**
+     * Instantiates new UserNatural object.
+     */
+    public LegacyUserNatural() {
+        this.personType = NATURAL;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public long getBirthday() {
+        return birthday;
+    }
+
+    public void setBirthday(long birthday) {
+        this.birthday = birthday;
+    }
+
+    public String getBirthplace() {
+        return birthplace;
+    }
+
+    public void setBirthplace(String birthplace) {
+        this.birthplace = birthplace;
+    }
+
+    public CountryIso getNationality() {
+        return nationality;
+    }
+
+    public void setNationality(CountryIso nationality) {
+        this.nationality = nationality;
+    }
+
+    public CountryIso getCountryOfResidence() {
+        return countryOfResidence;
+    }
+
+    public void setCountryOfResidence(CountryIso countryOfResidence) {
+        this.countryOfResidence = countryOfResidence;
+    }
+
+    public String getOccupation() {
+        return occupation;
+    }
+
+    public void setOccupation(String occupation) {
+        this.occupation = occupation;
+    }
+
+    public Integer getIncomeRange() {
+        return incomeRange;
+    }
+
+    public void setIncomeRange(Integer incomeRange) {
+        this.incomeRange = incomeRange;
+    }
+
+    public String getProofOfIdentity() {
+        return proofOfIdentity;
+    }
+
+    public void setProofOfIdentity(String proofOfIdentity) {
+        this.proofOfIdentity = proofOfIdentity;
+    }
+
+    public String getProofOfAddress() {
+        return proofOfAddress;
+    }
+
+    public void setProofOfAddress(String proofOfAddress) {
+        this.proofOfAddress = proofOfAddress;
+    }
+
+    /**
+     * Gets the collection of read-only fields names.
+     *
+     * @return List of field names.
+     */
+    @Override
+    public ArrayList<String> getReadOnlyProperties() {
+
+        ArrayList<String> result = super.getReadOnlyProperties();
+
+        result.add("ProofOfIdentity");
+        result.add("ProofOfAddress");
+
+        return result;
+    }
+}

--- a/src/main/java/com/mangopay/entities/UserNatural.java
+++ b/src/main/java/com/mangopay/entities/UserNatural.java
@@ -13,7 +13,7 @@ import static com.mangopay.core.enumerations.PersonType.NATURAL;
 /**
  * UserNatural entity.
  */
-public final class UserNatural extends User {
+public class UserNatural extends User {
 
     /**
      * First name.

--- a/src/main/resources/com/mangopay/core/mangopay.properties
+++ b/src/main/resources/com/mangopay/core/mangopay.properties
@@ -1,2 +1,2 @@
-#Wed Feb 22 12:11:38 CET 2017
-version=1.3.0
+#Wed Jul 05 01:27:01 EEST 2017
+version=1.3.2

--- a/src/main/resources/com/mangopay/core/mangopay.properties
+++ b/src/main/resources/com/mangopay/core/mangopay.properties
@@ -1,2 +1,2 @@
-#Wed Jul 05 19:01:29 EEST 2017
-version=1.3.2
+#Wed Jul 05 19:16:28 EEST 2017
+version=2.0.0

--- a/src/main/resources/com/mangopay/core/mangopay.properties
+++ b/src/main/resources/com/mangopay/core/mangopay.properties
@@ -1,2 +1,2 @@
-#Wed Jul 05 01:27:01 EEST 2017
+#Wed Jul 05 19:01:29 EEST 2017
 version=1.3.2

--- a/src/test/java/com/mangopay/core/BaseTest.java
+++ b/src/test/java/com/mangopay/core/BaseTest.java
@@ -141,12 +141,13 @@ public abstract class BaseTest {
     }
 
     protected LegacyUserNatural getLegacyJohn() throws Exception {
-        if (BaseTest.JOHN == null) {
-            String initialVersion = api.getConfig().getApiVersion();
-            api.getConfig().setApiVersion(Configuration.VERSION_2_01);
-            getJohn();
-            api.getConfig().setApiVersion(initialVersion);
-
+        if (BaseTest.LEGACY_JOHN == null) {
+            if (BaseTest.JOHN == null) {
+                String initialVersion = api.getConfig().getApiVersion();
+                api.getConfig().setApiVersion(Configuration.VERSION_2_01);
+                getJohn();
+                api.getConfig().setApiVersion(initialVersion);
+            }
             BaseTest.LEGACY_JOHN = (LegacyUserNatural) this.api.getLegacyUserApi().get(BaseTest.JOHN.getId());
         }
         return BaseTest.LEGACY_JOHN;
@@ -197,12 +198,13 @@ public abstract class BaseTest {
     }
 
     protected LegacyUserLegal getLegacyMatrix() throws Exception {
-        if (BaseTest.MATRIX == null) {
-            String initialVersion = api.getConfig().getApiVersion();
-            api.getConfig().setApiVersion(Configuration.VERSION_2_01);
-            getMatrix();
-            api.getConfig().setApiVersion(initialVersion);
-
+        if (BaseTest.LEGACY_MATRIX == null) {
+            if (BaseTest.MATRIX == null) {
+                String initialVersion = api.getConfig().getApiVersion();
+                api.getConfig().setApiVersion(Configuration.VERSION_2_01);
+                getMatrix();
+                api.getConfig().setApiVersion(initialVersion);
+            }
             BaseTest.LEGACY_MATRIX = (LegacyUserLegal) this.api.getLegacyUserApi().get(BaseTest.MATRIX.getId());
         }
         return BaseTest.LEGACY_MATRIX;

--- a/src/test/java/com/mangopay/core/BaseTest.java
+++ b/src/test/java/com/mangopay/core/BaseTest.java
@@ -23,7 +23,9 @@ public abstract class BaseTest {
     protected MangoPayApi api;
 
     private static UserNatural JOHN;
+    private static LegacyUserNatural LEGACY_JOHN;
     private static UserLegal MATRIX;
+    private static LegacyUserLegal LEGACY_MATRIX;
     private static BankAccount JOHNS_ACCOUNT;
     private static Wallet JOHNS_WALLET;
     private static Wallet JOHNS_WALLET_WITH_MONEY;
@@ -69,7 +71,6 @@ public abstract class BaseTest {
         newApi.getConfig().setClientId("sdk-unit-tests");
         newApi.getConfig().setClientPassword("cqFfFrWfCcb7UadHNxx2C9Lo6Djw8ZduLi7J9USTmu8bhxxpju");
         newApi.getConfig().setDebugMode(true);
-        newApi.getConfig().setApiVersion(Configuration.VERSION_2);
 
         // register storage strategy for tests
         newApi.getOAuthTokenManager().registerCustomStorageStrategy(new DefaultStorageStrategyForTests());
@@ -139,6 +140,18 @@ public abstract class BaseTest {
         return BaseTest.JOHN;
     }
 
+    protected LegacyUserNatural getLegacyJohn() throws Exception {
+        if (BaseTest.JOHN == null) {
+            String initialVersion = api.getConfig().getApiVersion();
+            api.getConfig().setApiVersion(Configuration.VERSION_2_01);
+            getJohn();
+            api.getConfig().setApiVersion(initialVersion);
+
+            BaseTest.LEGACY_JOHN = (LegacyUserNatural) this.api.getLegacyUserApi().get(BaseTest.JOHN.getId());
+        }
+        return BaseTest.LEGACY_JOHN;
+    }
+
     protected UserNatural getNewJohn() throws Exception {
 
         Calendar c = Calendar.getInstance();
@@ -181,6 +194,18 @@ public abstract class BaseTest {
             BaseTest.MATRIX = (UserLegal) this.api.getUserApi().create(user);
         }
         return BaseTest.MATRIX;
+    }
+
+    protected LegacyUserLegal getLegacyMatrix() throws Exception {
+        if (BaseTest.MATRIX == null) {
+            String initialVersion = api.getConfig().getApiVersion();
+            api.getConfig().setApiVersion(Configuration.VERSION_2_01);
+            getMatrix();
+            api.getConfig().setApiVersion(initialVersion);
+
+            BaseTest.LEGACY_MATRIX = (LegacyUserLegal) this.api.getLegacyUserApi().get(BaseTest.MATRIX.getId());
+        }
+        return BaseTest.LEGACY_MATRIX;
     }
 
     protected BankAccount getJohnsAccount() throws Exception {
@@ -734,6 +759,25 @@ public abstract class BaseTest {
             assertEquals(((UserNatural) entity1).getOccupation(), ((UserNatural) entity2).getOccupation());
             assertEquals(((UserNatural) entity1).getIncomeRange(), ((UserNatural) entity2).getIncomeRange());
 
+        } else if (entity1 instanceof LegacyUserNatural) {
+            assertEquals(((LegacyUserNatural) entity1).getTag(), ((LegacyUserNatural) entity2).getTag());
+            assertEquals(((LegacyUserNatural) entity1).getPersonType(), ((LegacyUserNatural) entity2).getPersonType());
+            assertEquals(((LegacyUserNatural) entity1).getFirstName(), ((LegacyUserNatural) entity2).getFirstName());
+            assertEquals(((LegacyUserNatural) entity1).getLastName(), ((LegacyUserNatural) entity2).getLastName());
+            assertEquals(((LegacyUserNatural) entity1).getEmail(), ((LegacyUserNatural) entity2).getEmail());
+
+            if (((LegacyUserNatural) entity1).getAddress() == null) {
+                assertNull(((LegacyUserNatural) entity2).getAddress());
+            } else {
+                assertNotNull(((LegacyUserNatural) entity2).getAddress());
+                assertEquals(((LegacyUserNatural) entity1).getAddress(), ((LegacyUserNatural) entity2).getAddress());
+            }
+
+            assertEquals(((LegacyUserNatural) entity1).getBirthday(), ((LegacyUserNatural) entity2).getBirthday());
+            assertEquals(((LegacyUserNatural) entity1).getNationality(), ((LegacyUserNatural) entity2).getNationality());
+            assertEquals(((LegacyUserNatural) entity1).getCountryOfResidence(), ((LegacyUserNatural) entity2).getCountryOfResidence());
+            assertEquals(((LegacyUserNatural) entity1).getOccupation(), ((LegacyUserNatural) entity2).getOccupation());
+            assertEquals(((LegacyUserNatural) entity1).getIncomeRange(), ((LegacyUserNatural) entity2).getIncomeRange());
         } else if (entity1 instanceof UserLegal) {
             assertEquals(((UserLegal) entity1).getTag(), ((UserLegal) entity2).getTag());
             assertEquals(((UserLegal) entity1).getPersonType(), ((UserLegal) entity2).getPersonType());
@@ -756,6 +800,22 @@ public abstract class BaseTest {
             assertEquals(((UserLegal) entity1).getLegalRepresentativeNationality(), ((UserLegal) entity2).getLegalRepresentativeNationality());
             assertEquals(((UserLegal) entity1).getLegalRepresentativeCountryOfResidence(), ((UserLegal) entity2).getLegalRepresentativeCountryOfResidence());
 
+        } else if (entity1 instanceof LegacyUserLegal) {
+            assertEquals(((LegacyUserLegal) entity1).getTag(), ((LegacyUserLegal) entity2).getTag());
+            assertEquals(((LegacyUserLegal) entity1).getPersonType(), ((LegacyUserLegal) entity2).getPersonType());
+            assertEquals(((LegacyUserLegal) entity1).getName(), ((LegacyUserLegal) entity2).getName());
+            assertNotNull(((LegacyUserLegal) entity1).getHeadquartersAddress());
+            assertNotNull(((LegacyUserLegal) entity2).getHeadquartersAddress());
+            assertEquals(((LegacyUserLegal) entity1).getHeadquartersAddress(), ((LegacyUserLegal) entity2).getHeadquartersAddress());
+
+            assertEquals(((LegacyUserLegal) entity1).getLegalRepresentativeFirstName(), ((LegacyUserLegal) entity2).getLegalRepresentativeFirstName());
+            assertEquals(((LegacyUserLegal) entity1).getLegalRepresentativeLastName(), ((LegacyUserLegal) entity2).getLegalRepresentativeLastName());
+            //assertEquals("***** TEMPORARY API ISSUE: RETURNED OBJECT MISSES THIS PROP AFTER CREATION *****", ((LegacyUserLegal)entity1).LegalRepresentativeAddress, ((LegacyUserLegal)entity2).LegalRepresentativeAddress);
+            assertEquals(((LegacyUserLegal) entity1).getLegalRepresentativeEmail(), ((LegacyUserLegal) entity2).getLegalRepresentativeEmail());
+            //assertEquals("***** TEMPORARY API ISSUE: RETURNED OBJECT HAS THIS PROP CHANGED FROM TIMESTAMP INTO ISO STRING AFTER CREATION *****", ((LegacyUserLegal)entity1).LegalRepresentativeBirthday, ((LegacyUserLegal)entity2).LegalRepresentativeBirthday);
+            assertEquals(((LegacyUserLegal) entity1).getLegalRepresentativeBirthday(), ((LegacyUserLegal) entity2).getLegalRepresentativeBirthday());
+            assertEquals(((LegacyUserLegal) entity1).getLegalRepresentativeNationality(), ((LegacyUserLegal) entity2).getLegalRepresentativeNationality());
+            assertEquals(((LegacyUserLegal) entity1).getLegalRepresentativeCountryOfResidence(), ((LegacyUserLegal) entity2).getLegalRepresentativeCountryOfResidence());
         } else if (entity1 instanceof BankAccount) {
             assertEquals(((BankAccount) entity1).getTag(), ((BankAccount) entity2).getTag());
             assertEquals(((BankAccount) entity1).getUserId(), ((BankAccount) entity2).getUserId());

--- a/src/test/java/com/mangopay/core/BaseTest.java
+++ b/src/test/java/com/mangopay/core/BaseTest.java
@@ -69,6 +69,7 @@ public abstract class BaseTest {
         newApi.getConfig().setClientId("sdk-unit-tests");
         newApi.getConfig().setClientPassword("cqFfFrWfCcb7UadHNxx2C9Lo6Djw8ZduLi7J9USTmu8bhxxpju");
         newApi.getConfig().setDebugMode(true);
+        newApi.getConfig().setApiVersion(Configuration.VERSION_2);
 
         // register storage strategy for tests
         newApi.getOAuthTokenManager().registerCustomStorageStrategy(new DefaultStorageStrategyForTests());

--- a/src/test/java/com/mangopay/core/ClientApiImplTest.java
+++ b/src/test/java/com/mangopay/core/ClientApiImplTest.java
@@ -50,6 +50,9 @@ public class ClientApiImplTest extends BaseTest {
 
     @Test
     public void getClient() throws Exception {
+        if (this.api.getConfig().getApiVersion().equals(Configuration.VERSION_2)) {
+            return;
+        }
         Client client = this.api.getClientApi().get();
 
         assertNotNull(client);
@@ -58,6 +61,9 @@ public class ClientApiImplTest extends BaseTest {
 
     @Test
     public void updateClient() throws Exception {
+        if (api.getConfig().getApiVersion().equals(Configuration.VERSION_2)) {
+            return;
+        }
         Client client = this.api.getClientApi().get();
 
         Random rand = new Random();
@@ -76,7 +82,9 @@ public class ClientApiImplTest extends BaseTest {
 
     @Test
     public void uploadClientLogo() throws Exception {
-
+        if (api.getConfig().getApiVersion().equals(Configuration.VERSION_2)) {
+            return;
+        }
         URL url = getClass().getResource("/com/mangopay/core/TestKycPageFile.png");
         String filePath = new File(url.toURI()).getAbsolutePath();
 

--- a/src/test/java/com/mangopay/core/UserApiImplTest.java
+++ b/src/test/java/com/mangopay/core/UserApiImplTest.java
@@ -110,6 +110,46 @@ public class UserApiImplTest extends BaseTest {
     }
 
     @Test
+    public void getLegacyNatural() throws Exception {
+        this.api.getConfig().setApiVersion(Configuration.VERSION_2);
+
+        LegacyUserNatural legacyJohn = this.getLegacyJohn();
+        User user1 = this.api.getLegacyUserApi().get(legacyJohn.getId());
+        LegacyUserNatural user2 = this.api.getLegacyUserApi().getNatural(legacyJohn.getId());
+
+        assertTrue(user1.getPersonType().equals(PersonType.NATURAL));
+        assertTrue(user1.getId().equals(legacyJohn.getId()));
+        assertTrue(user2.getPersonType().equals(PersonType.NATURAL));
+        assertTrue(user2.getId().equals(legacyJohn.getId()));
+
+        assertEqualInputProps(user1, legacyJohn);
+    }
+
+    @Test
+    public void getLegal() throws Exception {
+        UserLegal matrix = this.getMatrix();
+
+        User user1 = this.api.getUserApi().get(matrix.getId());
+        User user2 = this.api.getUserApi().getLegal(matrix.getId());
+
+        assertEqualInputProps(user1, matrix);
+        assertEqualInputProps(user2, matrix);
+    }
+
+    @Test
+    public void getLegacyLegal() throws Exception {
+        this.api.getConfig().setApiVersion(Configuration.VERSION_2);
+
+        LegacyUserLegal legacyMatrix = this.getLegacyMatrix();
+
+        User user1 = this.api.getLegacyUserApi().get(legacyMatrix.getId());
+        User user2 = this.api.getLegacyUserApi().getLegal(legacyMatrix.getId());
+
+        assertEqualInputProps(user1, legacyMatrix);
+        assertEqualInputProps(user2, legacyMatrix);
+    }
+
+    @Test
     public void getNaturalFailsForLegalUser() throws Exception {
         UserLegal matrix = this.getMatrix();
 
@@ -135,17 +175,6 @@ public class UserApiImplTest extends BaseTest {
         } catch (ResponseException ex) {
             assertNull(user);
         }
-    }
-
-    @Test
-    public void getLegal() throws Exception {
-        UserLegal matrix = this.getMatrix();
-
-        User user1 = this.api.getUserApi().get(matrix.getId());
-        User user2 = this.api.getUserApi().getLegal(matrix.getId());
-
-        assertEqualInputProps(user1, matrix);
-        assertEqualInputProps(user2, matrix);
     }
 
     @Test
@@ -403,12 +432,12 @@ public class UserApiImplTest extends BaseTest {
     public void updateKycDocument() throws Exception {
         UserNatural john = this.getJohn();
         KycDocument kycDocument = this.getJohnsKycDocument();
-        
+
         URL url = getClass().getResource("/com/mangopay/core/TestKycPageFile.png");
         String filePath = new File(url.toURI()).getAbsolutePath();
 
         this.api.getUserApi().createKycPage(john.getId(), kycDocument.getId(), filePath);
-        
+
         kycDocument.setStatus(KycStatus.VALIDATION_ASKED);
 
         KycDocument result = this.api.getUserApi().updateKycDocument(john.getId(), kycDocument);


### PR DESCRIPTION
Updated the SDK, users can now use a Legacy version of the UserApi class (only after setting the API Version in Configuration to the older one), which returns Legacy versions of Natural/Legal User classes having String values instead of the newer, more complex objects as their Address fields.