### PR TITLE
Add missing country code from ISO_3166-1 Alpha 2 specification

### DIFF
--- a/src/main/java/com/mangopay/core/enumerations/CountryIso.java
+++ b/src/main/java/com/mangopay/core/enumerations/CountryIso.java
@@ -262,6 +262,10 @@ public enum CountryIso {
     */  
     DZ,
     /**
+     * Ceuta, Melilla
+     */
+    EA,
+    /**
     * Ecuador
     */  
     EC,
@@ -414,8 +418,12 @@ public enum CountryIso {
     */  
     HU,
     /**
+     * Canary Islands
+     */
+    IC,
+    /**
     * Indonesia
-    */  
+    */
     ID,
     /**
     * Ireland


### PR DESCRIPTION
Your implementation misses some countries specified in the ISO-3166-1 Alpha 2 document.

Cf. Support request _00D24JOOb._500241wtIaP