### PR TITLE
Fix settlement return object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ nbactions.xml
 /target/
 *.iml
 *.gpg
+
+### Eclipse ###
+.classpath
+.project
+.settings

--- a/src/main/java/com/mangopay/entities/SettlementTransfer.java
+++ b/src/main/java/com/mangopay/entities/SettlementTransfer.java
@@ -1,76 +1,25 @@
 package com.mangopay.entities;
 
 import com.google.gson.annotations.SerializedName;
-import com.mangopay.core.EntityBase;
-import com.mangopay.core.Money;
-
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Settlement transfer entity.
  */
-public class SettlementTransfer extends EntityBase {
-
+public class SettlementTransfer extends Transfer {
+    
     /**
-     * The Id of the author of the original PayIn that was repudiated.
+     * The repudiation id of the settlement
      */
-    @SerializedName("AuthorId")
-    private String authorId;
+    @SerializedName("RepudiationId")
+    private String repudiationId;
 
-    /**
-     * The funds debited from the debited wallet.
-     */
-    @SerializedName("DebitedFunds")
-    private Money debitedFunds;
-
-    /**
-     * The amount you wish to charge for this settlement.
-     * This can be equal to 0, or more than 0 to charge for the settlement or
-     * less than 0 to refund some of the original Fees that were taken on
-     * the original settlement (eg. DebitedFunds of 1000 and Fees of -200 will
-     * transfer 800 from the original wallet to the credit wallet, and transfer
-     * 200 from your Fees wallet to your Credit wallet.
-     */
-    @SerializedName("Fees")
-    private Money fees;
-
-    public String getAuthorId() {
-        return authorId;
+    public String getRepudiationId() {
+      return repudiationId;
     }
 
-    public void setAuthorId(String authorId) {
-        this.authorId = authorId;
+    public void setRepudiationId(String repudiationId) {
+      this.repudiationId = repudiationId;
     }
 
-    public Money getDebitedFunds() {
-        return debitedFunds;
-    }
 
-    public void setDebitedFunds(Money debitedFunds) {
-        this.debitedFunds = debitedFunds;
-    }
-
-    public Money getFees() {
-        return fees;
-    }
-
-    public void setFees(Money fees) {
-        this.fees = fees;
-    }
-
-    /**
-     * Gets map which property is an object and what type of object.
-     *
-     * @return Collection of field name-field type pairs.
-     */
-    @Override
-    public Map<String, Type> getSubObjects() {
-
-        return new HashMap<String, Type>() {{
-            put("DebitedFunds", Money.class);
-            put("Fees", Money.class);
-        }};
-    }
 }

--- a/src/main/resources/com/mangopay/core/mangopay.properties
+++ b/src/main/resources/com/mangopay/core/mangopay.properties
@@ -1,2 +1,2 @@
-#Mon Feb 10 15:14:07 EET 2020
+#Thu Apr 16 21:56:38 EEST 2020
 version=2.10.1


### PR DESCRIPTION
The API endpoint GET .../settlements/:SettlementId/ returns a Settlement object that has the following form:

```json
{
  "Id": "78911869",
  "Tag": null,
  "CreationDate": 1587063245,
  "ResultCode": "000000",
  "ResultMessage": "Success",
  "DebitedFunds": {
    "Currency": "EUR",
    "Amount": 107
  },
  "Fees": {
    "Currency": "EUR",
    "Amount": 0
  },
  "AuthorId": "60611642",
  "CreditedUserId": null,
  "CreditedFunds": {
    "Currency": "EUR",
    "Amount": 107
  },
  "Status": "SUCCEEDED",
  "ExecutionDate": 1587063245,
  "Type": "TRANSFER",
  "Nature": "SETTLEMENT",
  "CreditedWalletId": "CREDIT_EUR",
  "DebitedWalletId": "60611643",
  "RepudiationId": "78911861"
}
```


The SDK method get from SettlementApiImpl.java, that wraps the endpoint above, returns an object of type SettlementTransfer.java. This object is not the same as as the api endpoint response.
This is a json serialization of the java object SettlementTransfer.java:
```json
{
  "Id": "78911869",
  "Tag": null,
  "CreationDate": 1587063245,
  "AuthorId": "60611642",
  "DebitedFunds": {
    "Currency": "EUR",
    "Amount": 107
  },
  "Fees": {
    "Currency": "EUR",
    "Amount": 0
  }
}
```

This pull request resolves this discrepancy between the response of the API and the response of the SDK

#130 

