### PR TITLE
Don't send POST with Content-Type and null body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ nbactions.xml
 .project
 .settings
 out
+bin

--- a/src/main/java/com/mangopay/core/APIs/implementation/UboDeclarationApiImpl.java
+++ b/src/main/java/com/mangopay/core/APIs/implementation/UboDeclarationApiImpl.java
@@ -27,7 +27,7 @@ public class UboDeclarationApiImpl extends ApiBase implements UboDeclarationApi 
 
     @Override
     public UboDeclaration create(String userId) throws Exception {
-        return this.createObject(UboDeclaration.class,null,"ubo_declaration_create",null,userId);
+        return this.createObject(UboDeclaration.class,null,"ubo_declaration_create",new UboDeclaration(),userId);
     }
 
     @Override


### PR DESCRIPTION
When a UboDeclaration is created, the SDK creates a POST request with the header Content-Type:application/json and a null body. 

The server responds fine but there is a situation: null is not a json.

In my setup I have a server that runs in memory that mocks the mangopay server for my unit-tests that does not accept this combination, forcing me to use the SDK source code modified, instead of the jar published in the maven repository as a dependency.

The solutions that I found and comply with the internet standards are:
1. A POST request with the header Content-Type:application/json must have a json body
2. A POST request with a null/empty body must not have a Content-Type header

Looking more at your teams, especially the one that made the mangopay-php-sdk, I saw that they approached the problem with the first solution, kind of. They made a special case when creating the UboDeclaration [here](https://github.com/Mangopay/mangopay2-php-sdk/blob/1e0792e77ba1fa6eb9536c36c1981ad189bfeff7/MangoPay/Libraries/ApiBase.php#L260) and did not allow a null body to be sent to the server.

```php
        if (is_null($requestData) && $responseClassName == '\MangoPay\UboDeclaration') {
            $requestData = "";
        }
```

I made a [pull request](https://github.com/Mangopay/mangopay2-java-sdk/pull/259) with the same approach but was rejected for a language technicality, that basically is the same as the php version. I don't know why you allow it in php but decline it in java, but it doesn't matter.

```java
        if (entity == null && classOfT.equals(UboDeclaration.class)) {
          entity = (U) new UboDeclaration();
        }
```


This is my second proposal: to just send an empty object as the parameter. I found this as being the least invasive way to make this work. It does not break the tests or the functionality and does not contain any language generics.

Now, you can decline this PR too, but it will be very helpful if you guys came up with a solution to this situation.

I admit I was not very inspired when I chose to use a in memory server to mock the mangopay server, I should of just mocked the methods, but now it's to late, I have around 1500 unittests in place. 

If you have another solution in mind just tell me about it and I'll make a PR.

Thanks




