### PR TITLE
Make `PayInReferences` attributes readable and instantiable

### DIFF
--- a/src/main/java/com/mangopay/core/enumerations/PayInReferences.java
+++ b/src/main/java/com/mangopay/core/enumerations/PayInReferences.java
@@ -5,4 +5,17 @@ public class PayInReferences {
     private String type;
 
     private String value;
+
+    public PayInReferences(String type, String value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getValue() {
+        return value;
+    }
 }


### PR DESCRIPTION
Make the `PayInReferences` class [introduced in version 2.40.0](https://github.com/Mangopay/mangopay2-java-sdk/compare/2.39.0...2.40.0#diff-507996cbaa814f79f3e2933e3b20723c0bd599663987421ec85a27bed23405e2R3) attributes readable and instantiable